### PR TITLE
fix as 3.0 import file error ;maxlineLength no exist

### DIFF
--- a/config/quality/checkstyle/checkstyle-config.xml
+++ b/config/quality/checkstyle/checkstyle-config.xml
@@ -42,7 +42,7 @@
         </module>
 
         <module name="LeftCurly">
-            <property name="maxLineLength" value="100"/>
+            <!-- <property name="maxLineLength" value="100"/> -->
         </module>
 
         <module name="RightCurly">


### PR DESCRIPTION
when use checkstyle-idea with as3.0,import checkstyle file error ;
cannot initialize module property 'maxLineLength' in module leftCurly does not exist.